### PR TITLE
Add load from diagnostic-path option and improved compatibility with older LS versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.0
+ - Bumped a few dependencies.
+ - Added a command option (`diagnostic-path`) to poll the data from a Logstash diagnostic path.
+ - Improved compatibility with older Logstash versions (7.x), which graph API is not supported.
+ - The pipeline components view now shows the plugin's pipeline usage and the dropped events percentages.
+ - Added a few plugin's extra details on the pipeline view.
+
 ## 0.2.0
 - Added a new `flows` view built on top of the latest Logstash flow metrics.
 - **BREAKING**: Renamed the `view` command to `tui`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,12 +40,6 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
-
-[[package]]
-name = "base64"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
@@ -61,12 +55,6 @@ name = "bitflags"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
-
-[[package]]
-name = "bumpalo"
-version = "3.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "bytecount"
@@ -146,11 +134,10 @@ checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "colored"
-version = "2.0.4"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
 dependencies = [
- "is-terminal",
  "lazy_static",
  "windows-sys 0.48.0",
 ]
@@ -218,27 +205,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
-name = "errno"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,12 +253,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
-
-[[package]]
 name = "human_format"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,27 +284,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c785eefb63ebd0e33416dfcb8d6da0bf27ce752843a45632a67bf10d4d4b5c4"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi",
- "rustix",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "itertools"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -354,15 +297,6 @@ name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
-
-[[package]]
-name = "js-sys"
-version = "0.3.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
-dependencies = [
- "wasm-bindgen",
-]
 
 [[package]]
 name = "json_to_table"
@@ -391,12 +325,6 @@ name = "libm"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "lock_api"
@@ -595,21 +523,21 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a564a852040e82671dc50a37d88f3aa83bbc690dfc6844cfe7a2591620206a80"
+checksum = "f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef"
 dependencies = [
  "bitflags 2.3.3",
  "cassowary",
  "compact_str",
  "crossterm",
- "indoc",
  "itertools",
  "lru",
  "paste",
  "stability",
  "strum",
  "unicode-segmentation",
+ "unicode-truncate",
  "unicode-width",
 ]
 
@@ -624,21 +552,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
@@ -646,44 +559,40 @@ dependencies = [
  "cc",
  "getrandom",
  "libc",
- "spin 0.9.8",
- "untrusted 0.9.0",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
-dependencies = [
- "bitflags 2.3.3",
- "errno",
- "libc",
- "linux-raw-sys",
+ "spin",
+ "untrusted",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
- "ring 0.17.7",
+ "ring",
+ "rustls-pki-types",
  "rustls-webpki",
- "sct",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.101.7"
+name = "rustls-pki-types"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
 dependencies = [
- "ring 0.17.7",
- "untrusted 0.9.0",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -703,16 +612,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "sct"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
-dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
-]
 
 [[package]]
 name = "serde"
@@ -792,12 +691,6 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
@@ -845,6 +738,12 @@ dependencies = [
  "rustversion",
  "syn 2.0.41",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -951,7 +850,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 name = "tuistash"
 version = "0.3.0"
 dependencies = [
- "base64 0.22.0",
+ "base64",
  "clap",
  "colored",
  "colored_json",
@@ -1000,16 +899,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
+name = "unicode-truncate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5fbabedabe362c618c714dbefda9927b5afc8e2a8102f47f081089a9019226"
+dependencies = [
+ "itertools",
+ "unicode-width",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -1019,14 +922,15 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.9.1"
+version = "2.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cdd25c339e200129fe4de81451814e5228c9b771d57378817d6117cc2b3f97"
+checksum = "d11a831e3c0b56e438a28308e7c810799e3c118417f342d30ecec080105395cd"
 dependencies = [
- "base64 0.21.0",
+ "base64",
  "log",
  "once_cell",
  "rustls",
+ "rustls-pki-types",
  "rustls-webpki",
  "serde",
  "serde_json",
@@ -1067,74 +971,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 1.0.107",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.107",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
-
-[[package]]
-name = "web-sys"
-version = "0.3.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "webpki-roots"
-version = "0.25.3"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
+checksum = "3c452ad30530b54a4d8e71952716a212b08efd0f3562baa66c29a618b07da7c3"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "winapi"
@@ -1315,3 +1158,9 @@ dependencies = [
  "quote",
  "syn 2.0.41",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +79,15 @@ name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -142,13 +157,26 @@ dependencies = [
 
 [[package]]
 name = "colored_json"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cff32df5cfea75e6484eeff0b4e48ad3977fb6582676a7862b3590dddc7a87"
+checksum = "e35980a1b846f8e3e359fd18099172a0857140ba9230affc4f71348081e039b6"
 dependencies = [
  "serde",
  "serde_json",
  "yansi",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -266,9 +294,9 @@ checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "human_format"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86cce260d758a9aa3d7c4b99d55c815a540f8a37514ba6046ab6be402a157cb0"
+checksum = "5c3b1f728c459d27b12448862017b96ad4767b1ec2ec5e6434e99f1577f085b8"
 
 [[package]]
 name = "humansize"
@@ -567,12 +595,13 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.25.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5659e52e4ba6e07b2dad9f1158f578ef84a73762625ddb51536019f34d180eb"
+checksum = "a564a852040e82671dc50a37d88f3aa83bbc690dfc6844cfe7a2591620206a80"
 dependencies = [
  "bitflags 2.3.3",
  "cassowary",
+ "compact_str",
  "crossterm",
  "indoc",
  "itertools",
@@ -775,13 +804,19 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stability"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd1b177894da2a2d9120208c3386066af06a488255caabc5de8ddca22dbc3ce"
+checksum = "2ff9eaf853dec4c8802325d8b6d3dffa86cc707fd7a1a4cdbf416e13b061787a"
 dependencies = [
  "quote",
- "syn 1.0.107",
+ "syn 2.0.41",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -791,18 +826,18 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -914,9 +949,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tuistash"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
- "base64",
+ "base64 0.22.0",
  "clap",
  "colored",
  "colored_json",
@@ -988,7 +1023,7 @@ version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8cdd25c339e200129fe4de81451814e5228c9b771d57378817d6117cc2b3f97"
 dependencies = [
- "base64",
+ "base64 0.21.0",
  "log",
  "once_cell",
  "rustls",
@@ -1257,9 +1292,9 @@ checksum = "d419259aba16b663966e29e6d7c6ecfa0bb8425818bb96f6f1f3c3eb71a6e7b9"
 
 [[package]]
 name = "yansi"
-version = "0.5.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,19 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.3.21", features = ["std", "derive", "help", "usage", "suggestions"], default-features = false }
-ureq = { version = "2.9.1", features = ["json", "tls"], default-features = false }
+ureq = { version = "2.9.7", features = ["json", "tls"], default-features = false }
 serde = { version = "1.0", features = ["derive"], default-features = false }
 serde_with = { version = "3.2.0", default-features = false }
 serde_json = { version = "1.0", default-features = false }
 tabled = { version = "0.14.0", features = ["std","default"] }
-colored = { version = "2.0.4", default-features = false }
+colored = { version = "2.1.0", default-features = false }
 json_to_table = { version = "0.5.0", default-features = false }
 base64 = { version = "0.22.0", features = ["std"], default-features = false }
-rustls = { version = "0.21", features = ["dangerous_configuration"], default-features = false }
+rustls = { version = "0.22.4", features = ["default", "tls12"], default-features = false }
 colored_json = { version = "5.0", default-features = false }
 humansize = { version = "2.1", default-features = false }
 humantime = { version = "2.1" }
-ratatui = { version = "0.26", features = ["crossterm", "unstable-rendered-line-info"] }
+ratatui = { version = "0.26.3", features = ["crossterm", "unstable-rendered-line-info"] }
 crossterm = { version = "0.27.0", default-features = false, features = ["event-stream"] }
 num-format = { version = "0.4", default-features = false, features = ["with-num-bigint"] }
 human_format = { version = "1.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ documentation = "https://github.com/edmocosta/tuistash"
 keywords = ["logstash", "tui", "cli", "terminal"]
 categories = ["command-line-utilities"]
 authors = ["Edmo Vamerlatti Costa <edinhow@gmail.com>"]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]
@@ -19,15 +19,15 @@ serde_json = { version = "1.0", default-features = false }
 tabled = { version = "0.14.0", features = ["std","default"] }
 colored = { version = "2.0.4", default-features = false }
 json_to_table = { version = "0.5.0", default-features = false }
-base64 = { version = "0.21", features = ["std"], default-features = false }
+base64 = { version = "0.22.0", features = ["std"], default-features = false }
 rustls = { version = "0.21", features = ["dangerous_configuration"], default-features = false }
-colored_json = { version = "4.1", default-features = false }
+colored_json = { version = "5.0", default-features = false }
 humansize = { version = "2.1", default-features = false }
 humantime = { version = "2.1" }
-ratatui = { version = "0.25", features = ["crossterm"] }
+ratatui = { version = "0.26", features = ["crossterm", "unstable-rendered-line-info"] }
 crossterm = { version = "0.27.0", default-features = false, features = ["event-stream"] }
 num-format = { version = "0.4", default-features = false, features = ["with-num-bigint"] }
-human_format = { version = "1.0" }
+human_format = { version = "1.1" }
 uuid = { version = "1.4", features = ["v4"] }
 time = { version = "0.3", features = ["default", "formatting", "local-offset"] }
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ cargo build --release
 
 ## Usage
 
-**The Logstash's [monitoring API](https://www.elastic.co/guide/en/logstash/current/monitoring-logstash.html) must be enabled
-and accessible from the client machine.**
+The Logstash's [monitoring API](https://www.elastic.co/guide/en/logstash/current/monitoring-logstash.html) must be enabled
+and accessible from the client machine, unless the data is being read from a Logstash diagnostic path.
 
 ```shell
 $ ./tuistash --help
@@ -55,12 +55,13 @@ Commands:
   help  Print this message or the help of the given subcommand(s)
 
 Options:
-      --host <HOST>            [default: http://localhost:9600]
-      --username <USERNAME>    
-      --password <PASSWORD>    
-      --skip-tls-verification  
-  -h, --help                   Print help
-  -V, --version                Print version
+      --host <HOST>                        [default: http://localhost:9600]
+      --username <USERNAME>                
+      --password <PASSWORD>                
+      --skip-tls-verification              
+  -p, --diagnostic-path <DIAGNOSTIC_PATH>  Read the data from a Logstash diagnostic path
+  -h, --help                               Print help
+  -V, --version                            Print version
 
 ```
 

--- a/src/cli/api/mod.rs
+++ b/src/cli/api/mod.rs
@@ -48,7 +48,7 @@ impl<'a> Client<'a> {
     ) -> Result<Self, AnyError> {
         let agent: Agent = if skip_tls_verification {
             let tls_config = rustls::ClientConfig::builder()
-                .with_safe_defaults()
+                .dangerous()
                 .with_custom_certificate_verifier(SkipServerVerification::new())
                 .with_no_client_auth();
 

--- a/src/cli/api/tls.rs
+++ b/src/cli/api/tls.rs
@@ -1,5 +1,10 @@
 use std::sync::Arc;
 
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{DigitallySignedStruct, Error, SignatureScheme};
+
+#[derive(Debug)]
 pub struct SkipServerVerification;
 
 impl SkipServerVerification {
@@ -8,16 +13,51 @@ impl SkipServerVerification {
     }
 }
 
-impl rustls::client::ServerCertVerifier for SkipServerVerification {
+impl ServerCertVerifier for SkipServerVerification {
     fn verify_server_cert(
         &self,
-        _end_entity: &rustls::Certificate,
-        _intermediates: &[rustls::Certificate],
-        _server_name: &rustls::ServerName,
-        _scts: &mut dyn Iterator<Item = &[u8]>,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
         _ocsp_response: &[u8],
-        _now: std::time::SystemTime,
-    ) -> Result<rustls::client::ServerCertVerified, rustls::Error> {
-        Ok(rustls::client::ServerCertVerified::assertion())
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        vec![
+            SignatureScheme::RSA_PKCS1_SHA1,
+            SignatureScheme::ECDSA_SHA1_Legacy,
+            SignatureScheme::RSA_PKCS1_SHA256,
+            SignatureScheme::ECDSA_NISTP256_SHA256,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::ECDSA_NISTP384_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA512,
+            SignatureScheme::ECDSA_NISTP521_SHA512,
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::RSA_PSS_SHA384,
+            SignatureScheme::RSA_PSS_SHA512,
+            SignatureScheme::ED25519,
+            SignatureScheme::ED448,
+        ]
     }
 }

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -21,6 +21,10 @@ pub struct Cli {
 
     #[arg(long, default_value_t = false, global = true)]
     pub skip_tls_verification: bool,
+
+    /// Read the data from a Logstash diagnostic path
+    #[arg(long, short = 'p', global = false)]
+    pub diagnostic_path: Option<String>,
 }
 
 pub fn build_cli() -> Cli {

--- a/src/cli/commands/formatter.rs
+++ b/src/cli/commands/formatter.rs
@@ -27,7 +27,10 @@ impl DurationFormatter for u64 {
         }
 
         let duration = *self as f64 / events_count as f64;
-        human_format::Formatter::new().format(duration)
+        human_format::Formatter::new()
+            .format(duration)
+            .trim()
+            .to_string()
     }
 }
 
@@ -37,6 +40,8 @@ pub trait NumberFormatter {
     }
 
     fn format_number_with_decimals(&self, decimals: usize) -> String;
+
+    fn strip_number_decimals(&self, decimals: usize) -> String;
 }
 
 impl NumberFormatter for i64 {
@@ -53,10 +58,25 @@ impl NumberFormatter for i64 {
                 .format(*self as f64),
         }
     }
+
+    fn strip_number_decimals(&self, _decimals: usize) -> String {
+        self.to_string()
+    }
 }
 
 impl NumberFormatter for f64 {
     fn format_number_with_decimals(&self, decimals: usize) -> String {
+        match self {
+            &f64::INFINITY => "Inf ".into(),
+            &f64::NEG_INFINITY => "-Inf ".into(),
+            0.0 => "0".into(),
+            _ => human_format::Formatter::new()
+                .with_decimals(decimals)
+                .format(*self),
+        }
+    }
+
+    fn strip_number_decimals(&self, decimals: usize) -> String {
         format!("{:.1$}", self, decimals)
     }
 }

--- a/src/cli/commands/node/command.rs
+++ b/src/cli/commands/node/command.rs
@@ -4,7 +4,7 @@ use crate::api::node::NodeInfoType;
 use crate::commands::node::output::OutputFormat;
 use crate::commands::traits::RunnableCommand;
 use crate::config::Config;
-use crate::errors::AnyError;
+use crate::errors::{AnyError, TuiError};
 use crate::output::Output;
 
 #[derive(Args)]
@@ -26,6 +26,13 @@ impl RunnableCommand<NodeArgs> for NodeCommand {
             None => OutputFormat::Default,
             Some(value) => OutputFormat::try_from(value.as_ref())?,
         };
+
+        if config.diagnostic_path.is_some() {
+            return Err(TuiError::from(
+                "The --diagnostic-path argument is not supported by the get command",
+            )
+            .into());
+        }
 
         let info_types = &NodeCommand::parse_info_types(&args.types)?;
         if output_format == OutputFormat::Raw {

--- a/src/cli/commands/tui/backend.rs
+++ b/src/cli/commands/tui/backend.rs
@@ -14,9 +14,12 @@ use ratatui::{
 };
 
 use crate::commands::tui::app::App;
+use crate::commands::tui::data_fetcher::{ApiDataFetcher, PathDataFetcher};
 use crate::commands::tui::ui;
 use crate::config::Config;
 use crate::errors::AnyError;
+
+const APP_TITLE: &str = "Logstash";
 
 pub fn run(interval: Duration, config: &Config) -> Result<(), AnyError> {
     enable_raw_mode()?;
@@ -29,11 +32,34 @@ pub fn run(interval: Duration, config: &Config) -> Result<(), AnyError> {
 
     terminal.clear()?;
 
-    run_app(
-        &mut terminal,
-        App::new("Logstash", config.api, interval),
-        interval,
-    )?;
+    if let Some(path) = &config.diagnostic_path {
+        match PathDataFetcher::new(path.to_string()) {
+            Ok(file_data_fetcher) => {
+                run_app(
+                    &mut terminal,
+                    App::new(
+                        APP_TITLE,
+                        &file_data_fetcher,
+                        path.to_string().as_str(),
+                        None,
+                    ),
+                )?;
+            }
+            Err(err) => {
+                return Err(err);
+            }
+        };
+    } else {
+        run_app(
+            &mut terminal,
+            App::new(
+                APP_TITLE,
+                &ApiDataFetcher::new(config.api),
+                config.api.base_url(),
+                Some(interval),
+            ),
+        )?;
+    };
 
     disable_raw_mode()?;
 
@@ -47,17 +73,15 @@ pub fn run(interval: Duration, config: &Config) -> Result<(), AnyError> {
     Ok(())
 }
 
-fn run_app<B: Backend>(
-    terminal: &mut Terminal<B>,
-    mut app: App,
-    interval: Duration,
-) -> io::Result<()> {
+fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<()> {
     let mut last_tick = Instant::now();
 
     app.on_tick();
 
     loop {
         terminal.draw(|f| ui::draw(f, &mut app))?;
+
+        let interval = app.sampling_interval.unwrap_or(Duration::from_secs(1));
 
         let timeout = interval
             .checked_sub(last_tick.elapsed())
@@ -71,7 +95,8 @@ fn run_app<B: Backend>(
                 }
             }
         }
-        if last_tick.elapsed() >= interval {
+
+        if app.sampling_interval.is_some() && last_tick.elapsed() >= interval {
             app.on_tick();
             last_tick = Instant::now();
         }

--- a/src/cli/commands/tui/data_decorator.rs
+++ b/src/cli/commands/tui/data_decorator.rs
@@ -1,0 +1,152 @@
+use std::cmp::Ordering;
+use std::collections::HashMap;
+
+use uuid::Uuid;
+
+use crate::api::node::{Edge, NodeInfo, Vertex};
+use crate::api::stats::{NodeStats, NodeStatsVertex};
+
+pub(crate) fn decorate(node_info: &mut NodeInfo, node_stats: &mut NodeStats) {
+    if !is_graph_api_available(&node_info.node.version) || has_empty_vertices(node_info) {
+        decorate_node_stats(node_stats);
+        decorate_node_info(node_info, node_stats);
+    }
+}
+
+fn has_empty_vertices(node_info: &NodeInfo) -> bool {
+    node_info
+        .pipelines
+        .as_ref()
+        .is_some_and(|p| p.values().any(|m| m.graph.graph.vertices.is_empty()))
+}
+
+// Pipeline graph/vertices API is available on version > 7.3.0
+fn is_graph_api_available(version: &str) -> bool {
+    let version: Vec<&str> = version.split('.').collect();
+    if let Some(major) = version.first() {
+        if let Ok(major) = major.parse::<u32>() {
+            if major < 7 {
+                return false;
+            } else if major > 7 {
+                return true;
+            } else if let Some(minor) = version.get(1) {
+                if let Ok(minor) = minor.parse::<u32>() {
+                    return minor >= 3;
+                }
+            }
+        }
+    }
+
+    false
+}
+
+fn decorate_node_stats(node_stats: &mut NodeStats) {
+    for stats in &mut node_stats.pipelines.values_mut() {
+        if stats.vertices.is_empty() {
+            let mut new_vertices: HashMap<String, NodeStatsVertex> = HashMap::new();
+            for (id, plugin) in stats.plugins.all() {
+                new_vertices.insert(
+                    id.to_string(),
+                    NodeStatsVertex {
+                        id: id.to_string(),
+                        pipeline_ephemeral_id: stats
+                            .ephemeral_id
+                            .as_deref()
+                            .map(|p| p.to_string())
+                            .unwrap_or(id),
+                        events_out: plugin.events.out,
+                        events_in: plugin.events.r#in,
+                        duration_in_millis: plugin.events.duration_in_millis,
+                        queue_push_duration_in_millis: plugin.events.queue_push_duration_in_millis,
+                    },
+                );
+            }
+            stats.vertices = new_vertices;
+        }
+    }
+}
+
+fn decorate_node_info(node_info: &mut NodeInfo, node_stats: &NodeStats) {
+    if let Some(pipelines) = &mut node_info.pipelines {
+        for (pipeline, info) in pipelines {
+            if info.graph.graph.vertices.is_empty() {
+                let pipeline_stats = node_stats.pipelines.get(pipeline).unwrap();
+                let mut new_vertices = vec![];
+                let mut new_edges = vec![];
+
+                for (id, (plugin_type, plugin)) in pipeline_stats.plugins.all_with_type() {
+                    if plugin_type == "codec" {
+                        continue;
+                    }
+
+                    new_vertices.push(Vertex {
+                        id: id.to_string(),
+                        explicit_id: id.len() != 64, // Guessed based on the generated ID size
+                        config_name: plugin
+                            .name
+                            .as_ref()
+                            .unwrap_or(&plugin.id.to_string())
+                            .to_string(),
+                        plugin_type: plugin_type.to_string(),
+                        condition: "".to_string(),
+                        r#type: "plugin".to_string(),
+                        meta: None,
+                    });
+                }
+
+                new_vertices.push(Vertex {
+                    id: "__QUEUE__".to_string(),
+                    explicit_id: false,
+                    config_name: "".to_string(),
+                    plugin_type: "".to_string(),
+                    condition: "".to_string(),
+                    r#type: "queue".to_string(),
+                    meta: None,
+                });
+
+                new_vertices.sort_by(|v1, v2| {
+                    if v1.plugin_type == v2.plugin_type {
+                        return v1.id.cmp(&v2.id);
+                    }
+
+                    if v1.plugin_type == "input" {
+                        return Ordering::Less;
+                    }
+
+                    if v2.plugin_type == "input" {
+                        return Ordering::Greater;
+                    }
+
+                    v1.plugin_type.cmp(&v2.plugin_type)
+                });
+
+                for i in 0..new_vertices.len() - 1 {
+                    let (plugin_type, from) = &new_vertices
+                        .get(i)
+                        .map(|p| (p.plugin_type.to_string(), p.id.to_string()))
+                        .unwrap_or(("".to_string(), "".to_string()));
+
+                    let to = if plugin_type == "input" {
+                        "__QUEUE__".to_string()
+                    } else {
+                        new_vertices
+                            .get(i + 1)
+                            .map(|p| p.id.to_string())
+                            .unwrap_or("".to_string())
+                    };
+
+                    new_edges.push(Edge {
+                        id: Uuid::new_v4().to_string(),
+                        from: from.to_string(),
+                        to,
+                        r#type: "".to_string(),
+                        when: None,
+                    });
+                }
+
+                info.graph.graph.vertices = new_vertices;
+                info.graph.graph.edges = new_edges;
+            }
+        }
+    }
+}

--- a/src/cli/commands/tui/data_fetcher.rs
+++ b/src/cli/commands/tui/data_fetcher.rs
@@ -1,26 +1,102 @@
+use std::fs;
+use std::path::Path;
+
 use crate::api::node::{NodeInfo, NodeInfoType};
 use crate::api::stats::NodeStats;
 use crate::api::Client;
-use crate::errors::AnyError;
+use crate::errors::{AnyError, TuiError};
 
-pub(crate) struct DataFetcher<'a> {
+pub(crate) trait DataFetcher<'a> {
+    fn fetch_info(&self) -> Result<NodeInfo, AnyError>;
+    fn fetch_stats(&self) -> Result<NodeStats, AnyError>;
+}
+
+pub(crate) struct ApiDataFetcher<'a> {
     api: &'a Client<'a>,
 }
 
-impl<'a> DataFetcher<'a> {
-    pub fn new(api: &'a Client) -> DataFetcher<'a> {
-        DataFetcher { api }
+impl<'a> ApiDataFetcher<'a> {
+    pub fn new(api: &'a Client) -> ApiDataFetcher<'a> {
+        ApiDataFetcher { api }
     }
+}
 
-    pub fn fetch_info(&self) -> Result<NodeInfo, AnyError> {
+impl<'a> DataFetcher<'a> for ApiDataFetcher<'a> {
+    fn fetch_info(&self) -> Result<NodeInfo, AnyError> {
         self.api.get_node_info(
             &[NodeInfoType::Pipelines],
             Some(Client::QUERY_NODE_INFO_GRAPH),
         )
     }
 
-    pub fn fetch_stats(&self) -> Result<NodeStats, AnyError> {
+    fn fetch_stats(&self) -> Result<NodeStats, AnyError> {
         self.api
             .get_node_stats(Some(Client::QUERY_NODE_STATS_VERTICES))
+    }
+}
+
+pub(crate) struct PathDataFetcher {
+    path: String,
+}
+
+const LOGSTASH_NODE_FILE: &str = "logstash_node.json";
+const LOGSTASH_NODE_STATS_FILE: &str = "logstash_node_stats.json";
+const LOGSTASH_DIAGNOSTIC_FILES: &[&str; 2] = &[LOGSTASH_NODE_FILE, LOGSTASH_NODE_STATS_FILE];
+
+impl PathDataFetcher {
+    fn validate_path(path: &str) -> Result<(), TuiError> {
+        let mut missing_files = vec![];
+
+        for file in LOGSTASH_DIAGNOSTIC_FILES {
+            let file_path = Path::new(path).join(file);
+            if !file_path.exists() || file_path.is_dir() {
+                missing_files.push(file.to_string());
+            }
+        }
+
+        if missing_files.is_empty() {
+            Ok(())
+        } else {
+            let message = format!(
+                "File(s) {} not found on the provided diagnostic path",
+                missing_files.join(", ").as_str()
+            );
+
+            Err(TuiError::from(message.as_str()))
+        }
+    }
+}
+
+impl PathDataFetcher {
+    pub fn new(path: String) -> Result<PathDataFetcher, AnyError> {
+        if let Err(err) = PathDataFetcher::validate_path(&path) {
+            Err(From::from(err))
+        } else {
+            Ok(PathDataFetcher { path })
+        }
+    }
+}
+
+impl<'a> DataFetcher<'a> for PathDataFetcher {
+    fn fetch_info(&self) -> Result<NodeInfo, AnyError> {
+        let path = Path::new(self.path.as_str()).join(LOGSTASH_NODE_FILE);
+        return match fs::read_to_string(path) {
+            Ok(data) => {
+                let node_info: NodeInfo = serde_json::from_str(data.as_str()).unwrap();
+                return Ok(node_info);
+            }
+            Err(err) => Err(err.into()),
+        };
+    }
+
+    fn fetch_stats(&self) -> Result<NodeStats, AnyError> {
+        let path = Path::new(self.path.as_str()).join(LOGSTASH_NODE_STATS_FILE);
+        return match fs::read_to_string(path) {
+            Ok(data) => {
+                let node_stats: NodeStats = serde_json::from_str(data.as_str()).unwrap();
+                return Ok(node_stats);
+            }
+            Err(err) => Err(err.into()),
+        };
     }
 }

--- a/src/cli/commands/tui/flow_charts.rs
+++ b/src/cli/commands/tui/flow_charts.rs
@@ -1,3 +1,4 @@
+use crate::commands::formatter::NumberFormatter;
 use crate::commands::tui::charts::{
     create_chart_float_label_spans, create_chart_timestamp_label_spans, ChartDataPoint,
     TimestampChartState, DEFAULT_LABELS_COUNT,
@@ -87,19 +88,19 @@ pub(crate) fn draw_plugin_throughput_flow_chart(
 
     let datasets = vec![
         Dataset::default()
-            .name(format!("Input: {:.3} e/s", input_throughput))
+            .name(format!("Input: {} e/s", input_throughput.format_number()))
             .marker(symbols::Marker::Braille)
             .graph_type(GraphType::Line)
             .style(Style::default().fg(Color::Blue))
             .data(&input_throughput_data),
         Dataset::default()
-            .name(format!("Filter: {:.3} e/s", filter_throughput))
+            .name(format!("Filter: {} e/s", filter_throughput.format_number()))
             .marker(symbols::Marker::Braille)
             .graph_type(GraphType::Line)
             .style(Style::default().fg(Color::Yellow))
             .data(&filter_throughput_data),
         Dataset::default()
-            .name(format!("Output: {:.3} e/s", output_throughput))
+            .name(format!("Output: {} e/s", output_throughput.format_number()))
             .marker(symbols::Marker::Braille)
             .graph_type(GraphType::Line)
             .style(Style::default().fg(Color::Magenta))
@@ -115,6 +116,7 @@ pub(crate) fn draw_flow_metric_chart(
     label_suffix: Option<&str>,
     state: &TimestampChartState<FlowMetricDataPoint>,
     area: Rect,
+    human_format: bool,
 ) {
     let metric_data: Vec<(f64, f64)> = state
         .data_points
@@ -123,11 +125,16 @@ pub(crate) fn draw_flow_metric_chart(
         .collect();
 
     let current_value = state.data_points.front().map(|p| p.value).unwrap_or(0.0);
+    let formatted_current_value = if human_format {
+        current_value.format_number()
+    } else {
+        current_value.strip_number_decimals(3)
+    };
 
     let datasets = vec![Dataset::default()
         .name(format!(
-            "Current: {:.3} {}",
-            current_value,
+            "Current: {} {}",
+            formatted_current_value,
             label_suffix.unwrap_or("")
         ))
         .marker(symbols::Marker::Braille)

--- a/src/cli/commands/tui/flows/state.rs
+++ b/src/cli/commands/tui/flows/state.rs
@@ -192,7 +192,7 @@ pub(crate) struct FlowsState {
     pub(crate) analysis_window_tabs: TabsState,
     pub(crate) show_as_percentage: bool,
     pub(crate) show_lifetime_values: bool,
-    pub(crate) show_selected_plugin: bool,
+    pub(crate) show_selected_pipeline: bool,
     pub(crate) current_focus: usize,
 }
 
@@ -205,7 +205,7 @@ impl FlowsState {
             analysis_window_tabs: TabsState::with_default_index(1),
             show_as_percentage: false,
             show_lifetime_values: false,
-            show_selected_plugin: false,
+            show_selected_pipeline: false,
             current_focus: PIPELINES_LIST,
         }
     }
@@ -236,7 +236,7 @@ impl FlowsState {
     }
 
     fn update_selected_pipeline_tables(&mut self, app_data: &AppData) {
-        if self.show_selected_plugin {
+        if self.show_selected_pipeline {
             if let Some(selected_pipeline) = self.pipelines_flow_table.selected_item() {
                 self.input_plugins_flow_table
                     .update(&selected_pipeline.name, app_data);
@@ -270,7 +270,7 @@ impl EventsListener for FlowsState {
 
     fn on_enter(&mut self, app_data: &AppData) {
         if self.current_focus == PIPELINES_LIST {
-            self.show_selected_plugin = !self.show_selected_plugin;
+            self.show_selected_pipeline = !self.show_selected_pipeline;
             self.update_selected_pipeline_tables(app_data);
         }
     }
@@ -284,7 +284,7 @@ impl EventsListener for FlowsState {
     }
 
     fn on_right(&mut self, _: &AppData) {
-        if self.current_focus == PIPELINES_LIST && self.show_selected_plugin {
+        if self.current_focus == PIPELINES_LIST && self.show_selected_pipeline {
             self.current_focus = PIPELINE_INPUTS_LIST;
             self.input_plugins_flow_table.next();
         }
@@ -338,7 +338,7 @@ impl EventsListener for FlowsState {
 
     fn on_other(&mut self, key_event: KeyEvent, _: &AppData) {
         // Tab navigation
-        if key_event.code == KeyCode::Tab && self.show_selected_plugin {
+        if key_event.code == KeyCode::Tab && self.show_selected_pipeline {
             if self.current_focus == PIPELINES_LIST {
                 self.current_focus = PIPELINE_INPUTS_LIST;
                 self.input_plugins_flow_table.next();

--- a/src/cli/commands/tui/mod.rs
+++ b/src/cli/commands/tui/mod.rs
@@ -8,6 +8,7 @@ mod data_fetcher;
 mod events;
 mod flow_charts;
 
+mod data_decorator;
 mod flows;
 mod node;
 mod pipelines;

--- a/src/cli/commands/tui/node/ui.rs
+++ b/src/cli/commands/tui/node/ui.rs
@@ -104,6 +104,7 @@ fn draw_node_charts(f: &mut Frame, app: &mut App, area: Rect) {
         None,
         &app.node_state.chart_flow_queue_backpressure,
         flow_chart_chunks[2],
+        false,
     );
 
     let node_chart_chunks = Layout::default()

--- a/src/cli/commands/tui/pipelines/graph.rs
+++ b/src/cli/commands/tui/pipelines/graph.rs
@@ -1,25 +1,10 @@
 use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
-use std::fmt::Debug;
 use uuid::Uuid;
 
 use crate::api::node::{GraphDefinition, Vertex};
 use crate::commands::tui::pipelines::state::PipelineTableItem;
-
-#[derive(Debug, Copy, Clone)]
-pub struct Stats {
-    pub events_in: Option<i64>,
-    pub events_out: Option<i64>,
-    pub duration_in_millis: Option<u64>,
-    pub queue_push_duration_in_millis: Option<u64>,
-}
-
-#[derive(Debug, Clone)]
-pub struct Node<'a> {
-    pub vertex: &'a Vertex,
-    pub stats: Option<&'a Stats>,
-}
 
 pub struct Data<'a, T> {
     pub value: &'a T,
@@ -123,7 +108,8 @@ impl<'a> PipelineGraph<'a> {
                     return line_order;
                 }
             }
-            Ordering::Equal
+
+            a_vertex.id.cmp(&b_vertex.id)
         }
     }
 
@@ -138,7 +124,7 @@ impl<'a> PipelineGraph<'a> {
     ) {
         if let Some(vertices) = graph.vertices.get(vertex_id) {
             if vertex_type == "if" {
-                let mut when_vertices = vec![vec![], vec![]];
+                let mut when_vertices = [vec![], vec![]];
                 let mut other_vertices = vec![];
 
                 for edge in vertices {

--- a/src/cli/commands/tui/ui.rs
+++ b/src/cli/commands/tui/ui.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::vec;
 
-use ratatui::layout::Alignment;
+use ratatui::layout::{Alignment, Flex};
 use ratatui::widgets::{Paragraph, Wrap};
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
@@ -37,6 +37,7 @@ pub(crate) fn draw(f: &mut Frame, app: &mut App) {
     f.render_widget(header_block, chunks[0]);
 
     let title_chunks = Layout::default()
+        .flex(Flex::Legacy)
         .constraints(
             [
                 Constraint::Length(28),
@@ -104,19 +105,20 @@ pub(crate) fn draw(f: &mut Frame, app: &mut App) {
         Span::styled("Connected", Style::default().fg(Color::Green))
     };
 
-    let status_text = Line::from(vec![
+    let mut status_text_spans = vec![
         conn_status_span,
         Span::styled(" @ ", Style::default().fg(Color::Gray)),
         Span::from(app.host),
-        Span::styled(
-            format!(" | Sampling every {}s", app.refresh_interval.as_secs()),
-            Style::default().fg(Color::Gray),
-        ),
-    ]);
+    ];
 
-    let w = Paragraph::new(status_text)
-        .alignment(Alignment::Right)
-        .wrap(Wrap { trim: true });
+    if let Some(interval) = app.sampling_interval {
+        status_text_spans.push(Span::styled(
+            format!(" | Sampling every {}s", interval.as_secs()),
+            Style::default().fg(Color::Gray),
+        ));
+    }
+
+    let w = Paragraph::new(Line::from(status_text_spans)).alignment(Alignment::Right);
 
     f.render_widget(w, title_chunks[2]);
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -2,4 +2,5 @@ use crate::api;
 
 pub struct Config<'a> {
     pub api: &'a api::Client<'a>,
+    pub diagnostic_path: Option<String>,
 }

--- a/src/cli/errors.rs
+++ b/src/cli/errors.rs
@@ -1,1 +1,25 @@
-pub type AnyError = Box<dyn std::error::Error + Send + Sync + 'static>;
+use std::fmt::{Display, Formatter};
+use std::{error::Error, fmt};
+
+pub type AnyError = Box<dyn Error + Send + Sync + 'static>;
+
+#[derive(Debug)]
+pub struct TuiError {
+    message: String,
+}
+
+impl TuiError {
+    pub fn from(message: &str) -> Self {
+        TuiError {
+            message: message.to_string(),
+        }
+    }
+}
+
+impl Error for TuiError {}
+
+impl Display for TuiError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -20,7 +20,10 @@ fn run() -> Result<ExitCode, AnyError> {
     let username = cli.username.as_deref();
     let password = cli.password.as_deref();
     let api = api::Client::new(&cli.host, username, password, cli.skip_tls_verification).unwrap();
-    let config = Config { api: &api };
+    let config = Config {
+        api: &api,
+        diagnostic_path: cli.diagnostic_path,
+    };
 
     let stdout = std::io::stdout();
     let mut stdout_lock = stdout.lock();


### PR DESCRIPTION
 - Bumped a few dependencies.
 - Added a command option (`diagnostic-path`) to poll the data from a Logstash diagnostic path.
 - Improved compatibility with older Logstash versions (7.x), which graph API is not supported.
 - The pipeline components view now shows the plugin's pipeline usage and the dropped events percentages.
 - Added a few plugin's extra details on the pipeline view.